### PR TITLE
Addressing Issue #11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(BUILD_UNIT_TESTS)
 endif(BUILD_UNIT_TESTS)
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "-fno-rtti -fno-exceptions -ffast-math ${CMAKE_CXX_FLAGS}")
+	set(CMAKE_CXX_FLAGS "-std=c++11 -fno-rtti -fno-exceptions -ffast-math ${CMAKE_CXX_FLAGS}")
 	set(CMAKE_CXX_FLAGS_RELEASE "-fomit-frame-pointer ${CMAKE_CXX_FLAGS_RELEASE}")
 	set(CMAKE_C_FLAGS "-ffast-math ${CMAKE_C_FLAGS}")
 	set(CMAKE_C_FLAGS_RELEASE "-fomit-frame-pointer ${CMAKE_C_FLAGS_RELEASE}")
@@ -93,4 +93,3 @@ if(NOT MARSHMALLOW_LIBRARY_ONLY AND UNIX)
 	                    WORLD_READ WORLD_EXECUTE
 	        COMPONENT deployment)
 endif()
-

--- a/include/core/logger.h
+++ b/include/core/logger.h
@@ -47,7 +47,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#define MMLOG(type, x) std::cerr << __FILE__ << ":" << __LINE__ << " ["type"]" << std::endl \
+#define MMLOG(type, x) std::cerr << __FILE__ << ":" << __LINE__ << " [" << type << "]" << std::endl \
                                  << "\t" << MMFUNCTION << ": " << x << std::endl
 
 #define MMFATAL(x) MMLOG("FATAL", x), exit(-1)


### PR DESCRIPTION
Turns out this was stupid simple.  logger.h had old-style string concat going on in a cout chain; just had to add the `<<`'s.

Commit comment:
- Set C++ standard to c++11
- Fixed cout err in MMLOG that was preventing use of c++11

Note: this does not fix the submodule update with Box2D.  Figured you'd handle that yourself if you get to it.
